### PR TITLE
Feat 3376 qas

### DIFF
--- a/src/components/dashboard/UserExtendedInsights.tsx
+++ b/src/components/dashboard/UserExtendedInsights.tsx
@@ -1025,7 +1025,7 @@ export function UserExtendedInsights({
           </div>
           
           {/* WeeklyStatsAnalytics Component */}
-          <WeeklyStatsAnalytics data={data} embedded={true} />
+          <WeeklyStatsAnalytics data={data} />
         </div>
       </Card>
 

--- a/src/components/dashboard/WeeklyStatsAnalytics.tsx
+++ b/src/components/dashboard/WeeklyStatsAnalytics.tsx
@@ -641,7 +641,7 @@ export function WeeklyStatsAnalytics({ data, className = '' }: TimeSeriesAnalyti
         })
         emailMapping = Object.entries(emailRuntimes)
           .sort(([, a], [, b]) => b - a)
-          .map(([email, minutes]) => `${email} (${minutes} min)`)
+          .map(([email, minutes]) => `${email} (${(minutes / 60).toFixed(2)} hrs)`)
       }
 
       return {
@@ -655,7 +655,7 @@ export function WeeklyStatsAnalytics({ data, className = '' }: TimeSeriesAnalyti
                activeView === 'activeBuildspaces' ? 'Active Buildspaces' :
                activeView === 'prompts' ? 'Total Prompts' :
                activeView === 'agenticTasks' ? 'Agentic Tasks' :
-               activeView === 'runtime' ? 'Runtime (minutes)' : 'Total Cost ($)',
+               activeView === 'runtime' ? 'Runtime' : 'Total Cost',
         emailMapping
       }
     })
@@ -711,7 +711,7 @@ export function WeeklyStatsAnalytics({ data, className = '' }: TimeSeriesAnalyti
                               activeView === 'cost' 
                                 ? `$${data.value.toFixed(2)}` 
                                 : activeView === 'runtime'
-                                ? `${data.value.toLocaleString()} min`
+                                ? `${(data.value / 60).toFixed(2)} hrs`
                                 : data.value.toLocaleString()
                             }
                           </div>
@@ -809,7 +809,7 @@ export function WeeklyStatsAnalytics({ data, className = '' }: TimeSeriesAnalyti
                             activeView === 'cost' 
                               ? `$${data.value.toFixed(2)}` 
                               : activeView === 'runtime'
-                              ? `${data.value.toLocaleString()} min`
+                              ? `${(data.value / 60).toFixed(2)} hrs`
                               : data.value.toLocaleString()
                           }
                         </div>


### PR DESCRIPTION
PS C:\Users\gananthakrishnan\Desktop\KTern\ktern-codegenie-adoption> npm run build

> ktern-codegenie-adoption@0.1.0 build
> next build

   ▲ Next.js 14.0.4
   - Environments: .env.local
   - Experiments (use at your own risk):
     · esmExternals

Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
(node:30252) [DEP_WEBPACK_MODULE_UPDATE_HASH] DeprecationWarning: Module.updateHash: Use new ChunkGraph API
(Use `node --trace-deprecation ...` to show where the warning was created)
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
 ✓ Creating an optimized production build    
 ✓ Compiled successfully
 ✓ Linting and checking validity of types    
 ✓ Collecting page data    
 ✓ Generating static pages (6/6)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /                                    1.95 kB        84.1 kB
├ ○ /_not-found                          872 B            83 kB
├ ○ /dashboard                           186 kB          769 kB
└ ○ /login                               3.69 kB        85.8 kB
+ First Load JS shared by all            82.1 kB
  ├ chunks/938-74e355b1249b68b9.js       26.8 kB
  ├ chunks/fd9d1056-7b27dfba7cbc1966.js  53.3 kB
  ├ chunks/main-app-1dc0a770e4e73878.js  224 B
  └ chunks/webpack-a2bf7ac05e1fad6e.js   1.84 kB


○  (Static)  prerendered as static content