### PR TITLE
added runtime to table

### DIFF
--- a/src/components/dashboard/UserExtendedInsights.tsx
+++ b/src/components/dashboard/UserExtendedInsights.tsx
@@ -835,7 +835,7 @@ export function UserExtendedInsights({
       valueGetter: (params) => {
         if (!params.data) return 0
         if (params.data.taskId === 'devzone_tracking') {
-          return Number((params.data as any).devzone_total_runtime_minutes || 0)
+          return Number((params.data as any).devzone_total_runtime_minutes || (params.data as any).duration_minutes || 0)
         }
         return 0
       },

--- a/src/components/dashboard/UserExtendedInsights.tsx
+++ b/src/components/dashboard/UserExtendedInsights.tsx
@@ -835,7 +835,7 @@ export function UserExtendedInsights({
       valueGetter: (params) => {
         if (!params.data) return 0
         if (params.data.taskId === 'devzone_tracking') {
-          return Number((params.data as any).devzone_total_runtime_minutes || (params.data as any).duration_minutes || 0)
+          return Number((params.data as any).duration_minutes || 0)
         }
         return 0
       },


### PR DESCRIPTION
 ✓ Creating an optimized production build    
 ✓ Compiled successfully
 ✓ Linting and checking validity of types    
 ✓ Collecting page data    
 ✓ Generating static pages (6/6)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /                                    1.95 kB        84.1 kB
├ ○ /_not-found                          872 B            83 kB
├ ○ /dashboard                           186 kB          769 kB
└ ○ /login                               3.69 kB        85.8 kB
+ First Load JS shared by all            82.1 kB
  ├ chunks/938-74e355b1249b68b9.js       26.8 kB
  ├ chunks/fd9d1056-7b27dfba7cbc1966.js  53.3 kB
  ├ chunks/main-app-1dc0a770e4e73878.js  224 B
  └ chunks/webpack-b0c3413f1e471c8c.js   1.84 kB